### PR TITLE
testing: upload the docker image after successful continuous build

### DIFF
--- a/.kokoro/python/continuous.cfg
+++ b/.kokoro/python/continuous.cfg
@@ -1,0 +1,5 @@
+# Upload the docker image after the successful build.
+env_vars: {
+    key: "TRAMPOLINE_IMAGE_UPLOAD"
+    value: "true"
+}


### PR DESCRIPTION
This change will tell Trampoline V2 script to upload the Docker image to `TRAMPOLINE_IMAGE` after the successful continuous build on Kokoro (I just changed it from periodic to continuous).

By uploading the image, future builds will be able to utilize the build cache, so that the `docker build` step will be significantly faster.

Trampoline V2 only uploads the image after successful builds.