### PR TITLE
testing: upload the docker image for public consumption

### DIFF
--- a/.kokoro/python/periodic.cfg
+++ b/.kokoro/python/periodic.cfg
@@ -1,0 +1,5 @@
+# Upload the docker image after the successful build.
+env_vars: {
+    key: "TRAMPOLINE_IMAGE_UPLOAD"
+    value: "true"
+}

--- a/.trampolinerc
+++ b/.trampolinerc
@@ -50,7 +50,7 @@ fi
 TRAMPOLINE_VERBOSE="true"
 
 public_image="gcr.io/cloud-devrel-public-resources/docker-ci-helper/python"
-function trampoline_upload_hook {
+function trampoline_after_upload_hook {
     log_yellow "Also uploading the Docker image to ${public_image}"
     docker tag "${TRAMPOLINE_IMAGE}" "${public_image}"
     if docker push "${public_image}"; then

--- a/.trampolinerc
+++ b/.trampolinerc
@@ -48,3 +48,14 @@ fi
 
 # The build will show some commands and docker build logs.
 TRAMPOLINE_VERBOSE="true"
+
+public_image="gcr.io/cloud-devrel-public-resources/docker-ci-helper/python"
+function trampoline_upload_hook {
+    log_yellow "Also uploading the Docker image to ${public_image}"
+    docker tag "${TRAMPOLINE_IMAGE}" "${public_image}"
+    if docker push "${public_image}"; then
+	log_green "Finished uploading ${public_image}."
+    else
+	log_red "Failed uploading the ${public_image}."
+    fi
+}

--- a/trampoline_v2.sh
+++ b/trampoline_v2.sh
@@ -64,7 +64,7 @@ else
   readonly IO_COLOR_RESET=""
 fi
 
-function fn_exists {
+function function_exists {
     [ $(LC_ALL=C type -t $1)"" == "function" ]
 }
 
@@ -425,9 +425,9 @@ if [[ "${update_cache}" == "true" ]] && \
     else
 	log_red "Failed uploading the Docker image."
     fi
-    # Call trampoline_upload_hook if it's defined.
-    if fn_exists trampoline_upload_hook; then
-	trampoline_upload_hook
+    # Call trampoline_after_upload_hook if it's defined.
+    if function_exists trampoline_upload_hook; then
+	trampoline_after_upload_hook
     fi
 
 fi

--- a/trampoline_v2.sh
+++ b/trampoline_v2.sh
@@ -64,6 +64,10 @@ else
   readonly IO_COLOR_RESET=""
 fi
 
+function fn_exists {
+    [ $(LC_ALL=C type -t $1)"" == "function" ]
+}
+
 # Logs a message using the given color. The first argument must be one
 # of the IO_COLOR_* variables defined above, such as
 # "${IO_COLOR_YELLOW}". The remaining arguments will be logged in the
@@ -421,6 +425,11 @@ if [[ "${update_cache}" == "true" ]] && \
     else
 	log_red "Failed uploading the Docker image."
     fi
+    # Call trampoline_upload_hook if it's defined.
+    if fn_exists trampoline_upload_hook; then
+	trampoline_upload_hook
+    fi
+
 fi
 
 exit "${test_retval}"

--- a/trampoline_v2.sh
+++ b/trampoline_v2.sh
@@ -426,7 +426,7 @@ if [[ "${update_cache}" == "true" ]] && \
 	log_red "Failed uploading the Docker image."
     fi
     # Call trampoline_after_upload_hook if it's defined.
-    if function_exists trampoline_upload_hook; then
+    if function_exists trampoline_after_upload_hook; then
 	trampoline_after_upload_hook
     fi
 


### PR DESCRIPTION
also enabled upload in Kokoro periodic builds

Currently only Kokoro build is using the service account. In other builds, we're using a public Docker image.

With this PR, the Kokoro continuous and periodic builds will upload the same image to `gcr.io/cloud-devrel-public-resources/docker-ci-helper/python` too so that non-Kokoro builds will benefit from the build cache.