### PR TITLE
add Kokoro build for the legacy Trampoline service account

### DIFF
--- a/.kokoro/python/legacy-presubmit.cfg
+++ b/.kokoro/python/legacy-presubmit.cfg
@@ -1,0 +1,21 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Use the legacy Trampoline service account in the bucket.
+env_vars: {
+    key: "TRAMPOLINE_USE_LEGACY_SERVICE_ACCOUNT"
+    value: "true"
+}

--- a/.kokoro/python/legacy-presubmit.cfg
+++ b/.kokoro/python/legacy-presubmit.cfg
@@ -14,6 +14,9 @@
 
 # Format: //devtools/kokoro/config/proto/build.proto
 
+# Download trampoline resources.
+gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
+
 # Use the legacy Trampoline service account in the bucket.
 env_vars: {
     key: "TRAMPOLINE_USE_LEGACY_SERVICE_ACCOUNT"

--- a/tests/python/test_envvar.py
+++ b/tests/python/test_envvar.py
@@ -76,7 +76,6 @@ def test_envvar():
             assert 'CIRCLE_JOB' in os.environ
             assert 'CIRCLE_NODE_INDEX' in os.environ
             assert 'CIRCLE_NODE_TOTAL' in os.environ
-            assert 'CIRCLE_PREVIOUS_BUILD_NUM' in os.environ
             assert 'CIRCLE_PROJECT_REPONAME' in os.environ
             assert 'CIRCLE_PROJECT_USERNAME' in os.environ
             assert 'CIRCLE_REPOSITORY_URL' in os.environ

--- a/trampoline_v2.sh
+++ b/trampoline_v2.sh
@@ -141,6 +141,8 @@ pass_down_envvars=(
     "TRAMPOLINE_VERSION"
 )
 
+log_yellow "Building with Trampoline ${TRAMPOLINE_VERSION}"
+
 mkdir -p "${tmpdir}/gcloud"
 gcloud_config_dir="${tmpdir}/gcloud"
 
@@ -270,8 +272,6 @@ required_envvars=(
 if [[ -f "${PROJECT_ROOT}/.trampolinerc" ]]; then
     source "${PROJECT_ROOT}/.trampolinerc"
 fi
-
-log_yellow "Building with Trampoline ${TRAMPOLINE_VERSION}"
 
 log_yellow "Checking environment variables."
 for e in "${required_envvars[@]}"


### PR DESCRIPTION
fixes #21

Note: We confirmed that the build failed without mounting the trampoline bucket:
https://source.cloud.google.com/results/invocations/3a05bd19-5a7c-4650-a7e2-a0c4162d96e8/targets