### PR TITLE
feat: support legacy style TRAMPOLINE_BUILD_FILE

### DIFF
--- a/.kokoro/python/legacy-presubmit.cfg
+++ b/.kokoro/python/legacy-presubmit.cfg
@@ -22,3 +22,10 @@ env_vars: {
     key: "TRAMPOLINE_USE_LEGACY_SERVICE_ACCOUNT"
     value: "true"
 }
+
+# Tell the trampoline which build file to use. We intentionally use
+# the legacy form of this value.
+env_vars: {
+    key: "TRAMPOLINE_BUILD_FILE"
+    value: "github/docker-ci-helper/tests/python/run_tests.sh"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,6 @@
 
 * 2.0.4
   support relative path for TRAMPOLINE_SERVICE_ACCOUNT envvar [#29](https://github.com/GoogleCloudPlatform/docker-ci-helper/pull/29)
+
+* 2.0.5
+  support legacy style TRAMPOLINE_BUILD_FILE [#30](https://github.com/GoogleCloudPlatform/docker-ci-helper/pull/30)

--- a/MIGRATING_FROM_V1.md
+++ b/MIGRATING_FROM_V1.md
@@ -191,9 +191,13 @@ allowed_env_vars: {
 
 With Trampoline V1, `TRAMPOLINE_BUILD_FILE` is in the form of
 `github/getting-started-python/.kokoro/.*`, but with Trampoline V2,
-you can not have `github/getting-started-python` part.
+you can omit `github/getting-started-python` part.
 
-So you may need to relax the regex if you have a strict one.
+This is cleaner because it is CI agnostic, but note that Trampoline V2
+also support the legacy form too.
+
+If you want to use the relative path, you may want to allow both cases
+temporarily.
 
 For example, this is the original configuration in our example repo:
 
@@ -205,8 +209,8 @@ allowed_env_vars: {
 }
 ```
 
-We want to change it to allow both cases(so that the change is not
-desruptive):
+You may want to change it to allow both cases(so that the change is
+not desruptive):
 
 ```# Allow configuring the trampoline build file.
 allowed_env_vars: {

--- a/MIGRATING_FROM_V1.md
+++ b/MIGRATING_FROM_V1.md
@@ -194,7 +194,7 @@ With Trampoline V1, `TRAMPOLINE_BUILD_FILE` is in the form of
 you can omit `github/getting-started-python` part.
 
 This is cleaner because it is CI agnostic, but note that Trampoline V2
-also support the legacy form too.
+also supports the legacy form too.
 
 If you want to use the relative path, you may want to allow both cases
 temporarily.

--- a/trampoline_v2.sh
+++ b/trampoline_v2.sh
@@ -287,6 +287,11 @@ do
     fi
 done
 
+# We want to support legacy style TRAMPOLINE_BUILD_FILE used with V1
+# script: e.g. "github/repo-name/.kokoro/run_tests.sh"
+TRAMPOLINE_BUILD_FILE="${TRAMPOLINE_BUILD_FILE#github/[^/]*/}"
+log_yellow "Using TRAMPOLINE_BUILD_FILE: ${TRAMPOLINE_BUILD_FILE}"
+
 # ignore error on docker operations and test execution
 set +e
 

--- a/trampoline_v2.sh
+++ b/trampoline_v2.sh
@@ -289,7 +289,7 @@ done
 
 # We want to support legacy style TRAMPOLINE_BUILD_FILE used with V1
 # script: e.g. "github/repo-name/.kokoro/run_tests.sh"
-TRAMPOLINE_BUILD_FILE="${TRAMPOLINE_BUILD_FILE#github/[^/]*/}"
+TRAMPOLINE_BUILD_FILE="${TRAMPOLINE_BUILD_FILE#github/[^/]+/}"
 log_yellow "Using TRAMPOLINE_BUILD_FILE: ${TRAMPOLINE_BUILD_FILE}"
 
 # ignore error on docker operations and test execution

--- a/trampoline_v2.sh
+++ b/trampoline_v2.sh
@@ -289,7 +289,7 @@ done
 
 # We want to support legacy style TRAMPOLINE_BUILD_FILE used with V1
 # script: e.g. "github/repo-name/.kokoro/run_tests.sh"
-TRAMPOLINE_BUILD_FILE="${TRAMPOLINE_BUILD_FILE#github/[^/]+/}"
+TRAMPOLINE_BUILD_FILE="${TRAMPOLINE_BUILD_FILE#github/*/}"
 log_yellow "Using TRAMPOLINE_BUILD_FILE: ${TRAMPOLINE_BUILD_FILE}"
 
 # ignore error on docker operations and test execution


### PR DESCRIPTION
This PR will make it easy to migrate from Trampoline V1.