### PR TITLE
fix: correct version string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,3 +27,6 @@
 
 * 2.0.9
   Comment update for Flaky Bot [#43](https://github.com/GoogleCloudPlatform/docker-ci-helper/pull/43)
+
+* 2.0.10
+  Correct verion string [#44](https://github.com/GoogleCloudPlatform/docker-ci-helper/pull/44)

--- a/trampoline_v2.sh
+++ b/trampoline_v2.sh
@@ -50,7 +50,7 @@
 
 set -euo pipefail
 
-TRAMPOLINE_VERSION="2.0.8"
+TRAMPOLINE_VERSION="2.0.10"
 
 if command -v tput >/dev/null && [[ -n "${TERM:-}" ]]; then
   readonly IO_COLOR_RED="$(tput setaf 1)"


### PR DESCRIPTION
The version 2.0.9 has a wrong version string `2.0.8`.