### PR TITLE
Update trampoline_v2.sh installation

### DIFF
--- a/MIGRATING_FROM_V1.md
+++ b/MIGRATING_FROM_V1.md
@@ -100,7 +100,6 @@ do it.
 * Using Secret Manager
 * Using files in `KOKORO_GFILE_DIR` or `KOKORO_KEYSTORE_DIR`
 
-
 Secret Manager is the recommended way. If you're using Secret Manager,
 only you need to do is to setup right permission to use Secret
 Manager.
@@ -167,13 +166,14 @@ from the Container Registry.
 There are two ways to do this:
 
 1. Attach a service account to the Kokoro VM
-2. Use the Trampoline service account in the `trampoline` GCS bucket.
+2. Use the Trampoline service account in the `trampoline` GCS bucket (**This will stop working**).
 
 While it is recommended to use the first option, many Kokoro builds
 with Trampoline V1 rely on a Trampoline service account stored in the
 `trampoline` GCS bucket.
 
-Trampoline supports both use cases.
+The Trampoline script supports both use cases but the restriction on exported
+keys is going to ban this usage.
 
 If you want to rely on the legacy Trampoline service account, you need
 to add `TRAMPOLINE_USE_LEGACY_SERVICE_ACCOUNT` to the environment

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ We'll discuss each steps in detail.
    downloaded Docker image, Trampoline V2 uses the downloaded image as
    a cache.
 
-We recomnend you have the Dockerfile in the same repository as your
+We recommend you have the Dockerfile in the same repository as your
 build file and your tests, then specify `TRAMPOLINE_DOCKERFILE`. This
 will allow you to create a single pull request containing changes in
 tests as well as changes in the Dockerfile.
@@ -188,13 +188,11 @@ Optional environment variables:
 
 ## Installation
 
-Please copy the `trampoline_v2.sh` to your repository (
+To use the trampoline script, copy the `trampoline_v2.sh` to your repository (
 [example in python-docs-samples](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.kokoro/trampoline_v2.sh)
 ) and set `build_file` in your Kokoro build configuration to the
 file ([example in python-docs-samples's python3.9 jobs](
 https://github.com/GoogleCloudPlatform/python-docs-samples/blob/6d2cb2fae50370b3f6b9ba17c48fa137ce7f3f5b/.kokoro/python3.9/common.cfg#L29)).
-
-
 
 ## Customization
 

--- a/README.md
+++ b/README.md
@@ -186,6 +186,16 @@ Optional environment variables:
 * `TRAMPOLINE_SERVICE_ACCOUNT`: A service account json file for
   authentication.
 
+## Installation
+
+Please copy the `trampoline_v2.sh` to your repository (
+[example in python-docs-samples](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.kokoro/trampoline_v2.sh)
+) and set `build_file` in your Kokoro build configuration to the
+file ([example in python-docs-samples's python3.9 jobs](
+https://github.com/GoogleCloudPlatform/python-docs-samples/blob/6d2cb2fae50370b3f6b9ba17c48fa137ce7f3f5b/.kokoro/python3.9/common.cfg#L29)).
+
+
+
 ## Customization
 
 You can add repo specific configuration by having `.trampolinerc` at


### PR DESCRIPTION
As discussed with @chingor13, It's not good to use the script stored in GCS as it's not verisoned.