### PR TITLE
feat: allow skipping user/group override

### DIFF
--- a/trampoline_v2.sh
+++ b/trampoline_v2.sh
@@ -40,8 +40,8 @@
 # TRAMPOLINE_BUILD_FILE: The script to run in the docker container.
 # TRAMPOLINE_WORKSPACE: The workspace path in the docker container.
 #                       Defaults to /workspace.
-# TRAMPOLINE_SKIP_USER: If set, run as the default user defined in the
-#                       docker image.
+# TRAMPOLINE_SKIP_USER: If set to "true", run as the default user
+#                       defined in the docker image.
 #
 # Potentially there are some repo specific envvars in .trampolinerc in
 # the project root.
@@ -427,7 +427,7 @@ docker_flags=(
 )
 
 # If TRAMPOLINE_SKIP_USER is set, then do not override the user we run as
-if [[ -z "${TRAMPOLINE_SKIP_USER}" ]]
+if [[ "${TRAMPOLINE_SKIP_USER:-}" == "true" ]]
 then
     docker_flags+=(
         # Run the docker script with the user id. Because the docker image gets to

--- a/trampoline_v2.sh
+++ b/trampoline_v2.sh
@@ -429,15 +429,15 @@ docker_flags=(
 # If TRAMPOLINE_SKIP_USER is set, then do not override the user we run as
 if [[ "${TRAMPOLINE_SKIP_USER:-}" != "true" ]]
 then
-    docker_flags+=(
-        # Run the docker script with the user id. Because the docker image gets to
-        # write in ${PWD} you typically want this to be your user id.
-        # To allow docker in docker, we need to use docker gid on the host.
-        "--user" "${user_uid}:${docker_gid}"
+  docker_flags+=(
+    # Run the docker script with the user id. Because the docker image gets to
+    # write in ${PWD} you typically want this to be your user id.
+    # To allow docker in docker, we need to use docker gid on the host.
+    "--user" "${user_uid}:${docker_gid}"
 
-        # Pass down the USER.
-        "--env" "USER=${user_name}"
-    )
+    # Pass down the USER.
+    "--env" "USER=${user_name}"
+  )
 fi
 
 # Add an option for nicer output if the build gets a tty.

--- a/trampoline_v2.sh
+++ b/trampoline_v2.sh
@@ -427,7 +427,7 @@ docker_flags=(
 )
 
 # If TRAMPOLINE_SKIP_USER is set, then do not override the user we run as
-if [[ "${TRAMPOLINE_SKIP_USER:-}" == "true" ]]
+if [[ "${TRAMPOLINE_SKIP_USER:-}" != "true" ]]
 then
     docker_flags+=(
         # Run the docker script with the user id. Because the docker image gets to


### PR DESCRIPTION
Some docker images expect to be running as a certain user. In those cases, we want to set the `TRAMPOLINE_SKIP_USER` flag and allow docker to run as the user configured in the image.