### PR TITLE
fix: keep the full buildfile name when using github

### DIFF
--- a/trampoline_v2.sh
+++ b/trampoline_v2.sh
@@ -302,9 +302,6 @@ do
   fi
 done
 
-# We want to support legacy style TRAMPOLINE_BUILD_FILE used with V1
-# script: e.g. "github/repo-name/.kokoro/run_tests.sh"
-TRAMPOLINE_BUILD_FILE="${TRAMPOLINE_BUILD_FILE#github/*/}"
 log_yellow "Using TRAMPOLINE_BUILD_FILE: ${TRAMPOLINE_BUILD_FILE}"
 
 # ignore error on docker operations and test execution


### PR DESCRIPTION
That is where the github repo gets copied to in the docker image