### PR TITLE
feat: add TRAMPOLINE_CONFIG_DIR which can contain a .trampolinerc

### DIFF
--- a/trampoline_v2.sh
+++ b/trampoline_v2.sh
@@ -294,7 +294,7 @@ if [[ "${CURRENT_DIR}" != "${PROJECT_ROOT}" && -f "${CURRENT_DIR}/.trampolinerc"
 fi
 
 # Allow specifying extra trampoline config directory
-if [[ ! -z "${TRAMPOLINE_CONFIG_DIR}" && -f "${TRAMPOLINE_CONFIG_DIR}" ]]; then
+if [[ ! -z "${TRAMPOLINE_CONFIG_DIR:-}" && -f "${TRAMPOLINE_CONFIG_DIR}" ]]; then
   source "${TRAMPOLINE_CONFIG_DIR}/.trampolinerc"
 fi
 

--- a/trampoline_v2.sh
+++ b/trampoline_v2.sh
@@ -293,6 +293,11 @@ if [[ "${CURRENT_DIR}" != "${PROJECT_ROOT}" && -f "${CURRENT_DIR}/.trampolinerc"
   source "${CURRENT_DIR}/.trampolinerc"
 fi
 
+# Allow specifying extra trampoline config directory
+if [[ ! -z "${TRAMPOLINE_CONFIG_DIR:}" && -f "${TRAMPOLINE_CONFIG_DIR}" ]]; then
+  source "${TRAMPOLINE_CONFIG_DIR}/.trampolinerc"
+fi
+
 log_yellow "Checking environment variables."
 for e in "${required_envvars[@]}"
 do

--- a/trampoline_v2.sh
+++ b/trampoline_v2.sh
@@ -294,7 +294,7 @@ if [[ "${CURRENT_DIR}" != "${PROJECT_ROOT}" && -f "${CURRENT_DIR}/.trampolinerc"
 fi
 
 # Allow specifying extra trampoline config directory
-if [[ ! -z "${TRAMPOLINE_CONFIG_DIR:}" && -f "${TRAMPOLINE_CONFIG_DIR}" ]]; then
+if [[ ! -z "${TRAMPOLINE_CONFIG_DIR}" && -f "${TRAMPOLINE_CONFIG_DIR}" ]]; then
   source "${TRAMPOLINE_CONFIG_DIR}/.trampolinerc"
 fi
 


### PR DESCRIPTION
This is useful for shared copies of trampoline_v2.sh when the PROJECT_ROOT cannot be determined or cannot contain a .trampolinerc file